### PR TITLE
feat: お問い合わせ保存用APIを実装

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,6 +6,7 @@
       "dependencies": {
         "chanfana": "2.8.0",
         "hono": "4.7.10",
+        "nanoid": "5.0.9",
         "zod": "3.25.28",
       },
       "devDependencies": {
@@ -377,6 +378,8 @@
     "minimist": ["minimist@1.2.8", "", {}, "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="],
 
     "mustache": ["mustache@4.2.0", "", { "bin": { "mustache": "bin/mustache" } }, "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ=="],
+
+    "nanoid": ["nanoid@5.0.9", "", { "bin": { "nanoid": "bin/nanoid.js" } }, "sha512-Aooyr6MXU6HpvvWXKoVoXwKMs/KyVakWwg7xQfv5/S/RIgJMy0Ifa45H9qqYy7pTCszrHzP21Uk4PZq2HpEM8Q=="],
 
     "ohash": ["ohash@2.0.11", "", {}, "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ=="],
 

--- a/migrations/0002_create_contacts_table.sql
+++ b/migrations/0002_create_contacts_table.sql
@@ -1,0 +1,19 @@
+-- Create contacts table for storing customer inquiries
+DROP TABLE IF EXISTS contacts;
+CREATE TABLE IF NOT EXISTS contacts (
+  id TEXT PRIMARY KEY,
+  name TEXT NOT NULL,
+  email TEXT NOT NULL,
+  phone TEXT,
+  company TEXT,
+  subject TEXT NOT NULL,
+  message TEXT NOT NULL,
+  status TEXT NOT NULL DEFAULT 'new',
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL
+);
+
+-- Create indexes for better query performance
+CREATE INDEX IF NOT EXISTS idx_contacts_status ON contacts(status);
+CREATE INDEX IF NOT EXISTS idx_contacts_email ON contacts(email);
+CREATE INDEX IF NOT EXISTS idx_contacts_created_at ON contacts(created_at);

--- a/package.json
+++ b/package.json
@@ -9,13 +9,14 @@
     "check": "biome check",
     "check:fix": "biome check --write",
     "cf-typegen": "wrangler types",
-    "db:migrate:local": "wrangler d1 execute DB --local --file=./migrations/0001_create_tasks_table.sql",
-    "db:migrate:remote": "wrangler d1 execute DB --remote --file=./migrations/0001_create_tasks_table.sql",
+    "db:migrate:local": "wrangler d1 execute DB --local --file=./migrations/0001_create_tasks_table.sql && wrangler d1 execute DB --local --file=./migrations/0002_create_contacts_table.sql",
+    "db:migrate:remote": "wrangler d1 execute DB --remote --file=./migrations/0001_create_tasks_table.sql && wrangler d1 execute DB --remote --file=./migrations/0002_create_contacts_table.sql",
     "db:reset:local": "rm -rf .wrangler/state/ && echo '✅ Local D1 database has been reset. Run \"bun dev\" and \"bun run db:migrate:local\" to reinitialize.'"
   },
   "dependencies": {
     "chanfana": "2.8.0",
     "hono": "4.7.10",
+    "nanoid": "5.0.9",
     "zod": "3.25.28"
   },
   "devDependencies": {

--- a/src/endpoints/contactCreate.ts
+++ b/src/endpoints/contactCreate.ts
@@ -1,0 +1,135 @@
+import { OpenAPIRoute } from 'chanfana'
+import { nanoid } from 'nanoid'
+import { z } from 'zod'
+import type { AppContext } from '../types'
+import { ContactCreate } from '../types'
+
+export class ContactCreateAPI extends OpenAPIRoute {
+  schema = {
+    tags: ['Contacts'],
+    summary: 'Create a new contact',
+    request: {
+      body: {
+        content: {
+          'application/json': {
+            schema: ContactCreate,
+          },
+        },
+      },
+    },
+    responses: {
+      '201': {
+        description: 'Contact created successfully',
+        content: {
+          'application/json': {
+            schema: z.object({
+              success: z.boolean(),
+              data: z.object({
+                id: z.string(),
+                name: z.string(),
+                email: z.string(),
+                phone: z.string().nullable(),
+                company: z.string().nullable(),
+                subject: z.string(),
+                message: z.string(),
+                status: z.string(),
+                created_at: z.string(),
+                updated_at: z.string(),
+              }),
+            }),
+          },
+        },
+      },
+      '400': {
+        description: 'Invalid request',
+        content: {
+          'application/json': {
+            schema: z.object({
+              success: z.boolean(),
+              error: z.string(),
+            }),
+          },
+        },
+      },
+      '500': {
+        description: 'Internal server error',
+        content: {
+          'application/json': {
+            schema: z.object({
+              success: z.boolean(),
+              error: z.string(),
+            }),
+          },
+        },
+      },
+    },
+  }
+
+  async handle(c: AppContext) {
+    try {
+      const data = await this.getValidatedData<typeof this.schema>()
+      const contactData = data.body
+
+      const now = new Date().toISOString()
+      const id = nanoid()
+
+      const contact = {
+        id,
+        name: contactData.name,
+        email: contactData.email,
+        phone: contactData.phone || null,
+        company: contactData.company || null,
+        subject: contactData.subject,
+        message: contactData.message,
+        status: 'new',
+        created_at: now,
+        updated_at: now,
+      }
+
+      const result = await c.env.DB.prepare(
+        `INSERT INTO contacts (id, name, email, phone, company, subject, message, status, created_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      )
+        .bind(
+          contact.id,
+          contact.name,
+          contact.email,
+          contact.phone,
+          contact.company,
+          contact.subject,
+          contact.message,
+          contact.status,
+          contact.created_at,
+          contact.updated_at,
+        )
+        .run()
+
+      if (!result.success) {
+        return c.json(
+          {
+            success: false,
+            error: 'Failed to create contact',
+          },
+          500,
+        )
+      }
+
+      return c.json(
+        {
+          success: true,
+          data: contact,
+        },
+        201,
+      )
+    } catch (error) {
+      console.error('Contact creation error:', error)
+      return c.json(
+        {
+          success: false,
+          error: 'Database error occurred',
+        },
+        500,
+      )
+    }
+  }
+}

--- a/src/endpoints/contactFetch.ts
+++ b/src/endpoints/contactFetch.ts
@@ -1,0 +1,98 @@
+import { OpenAPIRoute } from 'chanfana'
+import { z } from 'zod'
+import type { AppContext } from '../types'
+
+export class ContactFetchAPI extends OpenAPIRoute {
+  schema = {
+    tags: ['Contacts'],
+    summary: 'Get a contact by ID',
+    request: {
+      params: z.object({
+        contactId: z.string().describe('Contact ID'),
+      }),
+    },
+    responses: {
+      '200': {
+        description: 'Contact details',
+        content: {
+          'application/json': {
+            schema: z.object({
+              success: z.boolean(),
+              data: z.object({
+                id: z.string(),
+                name: z.string(),
+                email: z.string(),
+                phone: z.string().nullable(),
+                company: z.string().nullable(),
+                subject: z.string(),
+                message: z.string(),
+                status: z.string(),
+                created_at: z.string(),
+                updated_at: z.string(),
+              }),
+            }),
+          },
+        },
+      },
+      '404': {
+        description: 'Contact not found',
+        content: {
+          'application/json': {
+            schema: z.object({
+              success: z.boolean(),
+              error: z.string(),
+            }),
+          },
+        },
+      },
+      '500': {
+        description: 'Internal server error',
+        content: {
+          'application/json': {
+            schema: z.object({
+              success: z.boolean(),
+              error: z.string(),
+            }),
+          },
+        },
+      },
+    },
+  }
+
+  async handle(c: AppContext) {
+    try {
+      const data = await this.getValidatedData<typeof this.schema>()
+      const { contactId } = data.params
+
+      const contact = await c.env.DB.prepare(
+        'SELECT id, name, email, phone, company, subject, message, status, created_at, updated_at FROM contacts WHERE id = ?',
+      )
+        .bind(contactId)
+        .first()
+
+      if (!contact) {
+        return c.json(
+          {
+            success: false,
+            error: 'Contact not found',
+          },
+          404,
+        )
+      }
+
+      return c.json({
+        success: true,
+        data: contact,
+      })
+    } catch (error) {
+      console.error('Contact fetch error:', error)
+      return c.json(
+        {
+          success: false,
+          error: 'Database error occurred',
+        },
+        500,
+      )
+    }
+  }
+}

--- a/src/endpoints/contactList.ts
+++ b/src/endpoints/contactList.ts
@@ -1,0 +1,117 @@
+import { OpenAPIRoute } from 'chanfana'
+import { z } from 'zod'
+import type { AppContext } from '../types'
+
+export class ContactListAPI extends OpenAPIRoute {
+  schema = {
+    tags: ['Contacts'],
+    summary: 'List contacts with pagination',
+    request: {
+      query: z.object({
+        page: z.number().int().min(1).default(1).describe('Page number'),
+        status: z
+          .enum(['new', 'in_progress', 'completed'])
+          .optional()
+          .describe('Filter by status'),
+      }),
+    },
+    responses: {
+      '200': {
+        description: 'List of contacts',
+        content: {
+          'application/json': {
+            schema: z.object({
+              success: z.boolean(),
+              data: z.array(
+                z.object({
+                  id: z.string(),
+                  name: z.string(),
+                  email: z.string(),
+                  phone: z.string().nullable(),
+                  company: z.string().nullable(),
+                  subject: z.string(),
+                  message: z.string(),
+                  status: z.string(),
+                  created_at: z.string(),
+                  updated_at: z.string(),
+                }),
+              ),
+              meta: z.object({
+                page: z.number(),
+                per_page: z.number(),
+                total: z.number(),
+                total_pages: z.number(),
+              }),
+            }),
+          },
+        },
+      },
+      '500': {
+        description: 'Internal server error',
+        content: {
+          'application/json': {
+            schema: z.object({
+              success: z.boolean(),
+              error: z.string(),
+            }),
+          },
+        },
+      },
+    },
+  }
+
+  async handle(c: AppContext) {
+    try {
+      const data = await this.getValidatedData<typeof this.schema>()
+      const { page, status } = data.query
+
+      // Build query
+      let query =
+        'SELECT id, name, email, phone, company, subject, message, status, created_at, updated_at FROM contacts'
+      const params: (string | number)[] = []
+
+      if (status !== undefined) {
+        query += ' WHERE status = ?'
+        params.push(status)
+      }
+
+      // Get total count
+      const countQuery = `SELECT COUNT(*) as count FROM contacts${status !== undefined ? ' WHERE status = ?' : ''}`
+      const countResult = await c.env.DB.prepare(countQuery)
+        .bind(...params)
+        .first<{ count: number }>()
+      const total = countResult?.count || 0
+
+      // Add pagination
+      const perPage = 20
+      const offset = (page - 1) * perPage
+      query += ' ORDER BY created_at DESC LIMIT ? OFFSET ?'
+      params.push(perPage, offset)
+
+      // Execute query
+      const result = await c.env.DB.prepare(query)
+        .bind(...params)
+        .all()
+
+      return c.json({
+        success: true,
+        data: result.results || [],
+        meta: {
+          page,
+          per_page: perPage,
+          total,
+          total_pages: Math.ceil(total / perPage),
+        },
+      })
+    } catch (error) {
+      console.error('Contact list error:', error)
+      return c.json(
+        {
+          success: false,
+          error: 'Database error occurred',
+        },
+        500,
+      )
+    }
+  }
+}

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -62,3 +62,90 @@ describe('Vecta Backend API', () => {
     expect(res.status).toBe(200)
   })
 })
+
+describe('Contacts API', () => {
+  test('allows access to contacts endpoint without API key in development', async () => {
+    const req = new Request('http://localhost/contacts')
+    const res = await app.fetch(req, {
+      DB: mockDB,
+      ENVIRONMENT: 'development',
+    })
+
+    expect(res.status).toBe(200)
+  })
+
+  test('creates a new contact in development', async () => {
+    const mockRunSuccess = {
+      prepare: () => ({
+        bind: () => ({
+          run: async () => ({ success: true }),
+        }),
+      }),
+    } as unknown as D1Database
+
+    const req = new Request('http://localhost/contacts', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        name: '山田太郎',
+        email: 'taro@example.com',
+        subject: 'お問い合わせテスト',
+        message: 'これはテストメッセージです。',
+      }),
+    })
+
+    const res = await app.fetch(req, {
+      DB: mockRunSuccess,
+      ENVIRONMENT: 'development',
+    })
+
+    expect(res.status).toBe(201)
+    const json = (await res.json()) as {
+      success: boolean
+      data: {
+        id: string
+        name: string
+        email: string
+        phone: string | null
+        company: string | null
+        subject: string
+        message: string
+        status: string
+        created_at: string
+        updated_at: string
+      }
+    }
+    expect(json.success).toBe(true)
+    expect(json.data.name).toBe('山田太郎')
+    expect(json.data.email).toBe('taro@example.com')
+  })
+
+  test('requires API key for contacts endpoint in production', async () => {
+    const req = new Request('http://localhost/contacts')
+    const res = await app.fetch(req, {
+      DB: mockDB,
+      ENVIRONMENT: 'production',
+    })
+
+    expect(res.status).toBe(401)
+    const json = (await res.json()) as { error: string }
+    expect(json.error).toBe('Unauthorized')
+  })
+
+  test('accepts valid API key for contacts in production', async () => {
+    const req = new Request('http://localhost/contacts', {
+      headers: {
+        'X-API-Key': 'test-api-key',
+      },
+    })
+    const res = await app.fetch(req, {
+      DB: mockDB,
+      ENVIRONMENT: 'production',
+      API_KEY: 'test-api-key',
+    })
+
+    expect(res.status).toBe(200)
+  })
+})

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,8 @@
 import { fromHono } from 'chanfana'
 import { Hono } from 'hono'
+import { ContactCreateAPI } from './endpoints/contactCreate'
+import { ContactFetchAPI } from './endpoints/contactFetch'
+import { ContactListAPI } from './endpoints/contactList'
 import { TaskCreate } from './endpoints/taskCreate'
 import { TaskDelete } from './endpoints/taskDelete'
 import { TaskFetch } from './endpoints/taskFetch'
@@ -20,13 +23,26 @@ app.use('/tasks/*', async (c, next) => {
   await next()
 })
 
+app.use('/contacts/*', async (c, next) => {
+  if (c.env.ENVIRONMENT !== 'development') {
+    return apiKeyAuth(c, next)
+  }
+  await next()
+})
+
 const openapi = fromHono(app, {
   docs_url: '/',
 })
 
+// Tasks endpoints
 openapi.get('/tasks', TaskList)
 openapi.post('/tasks', TaskCreate)
 openapi.get('/tasks/:taskSlug', TaskFetch)
 openapi.delete('/tasks/:taskSlug', TaskDelete)
+
+// Contacts endpoints
+openapi.get('/contacts', ContactListAPI)
+openapi.post('/contacts', ContactCreateAPI)
+openapi.get('/contacts/:contactId', ContactFetchAPI)
 
 export default app

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import { DateTime, Str } from 'chanfana'
+import { DateTime, Email, Str } from 'chanfana'
 import type { Context } from 'hono'
 import { z } from 'zod'
 
@@ -10,4 +10,54 @@ export const Task = z.object({
   description: Str({ required: false }),
   completed: z.boolean().default(false),
   due_date: DateTime({ required: false }),
+})
+
+export const Contact = z.object({
+  id: Str(),
+  name: Str({ example: '山田太郎', description: 'お名前' }),
+  email: Email({ example: 'taro@example.com', description: 'メールアドレス' }),
+  phone: Str({
+    required: false,
+    example: '03-1234-5678',
+    description: '電話番号',
+  }),
+  company: Str({
+    required: false,
+    example: '株式会社Example',
+    description: '会社名',
+  }),
+  subject: Str({
+    example: 'サービスについてのお問い合わせ',
+    description: '件名',
+  }),
+  message: Str({
+    example: 'サービスの詳細について教えてください。',
+    description: 'お問い合わせ内容',
+  }),
+  status: z.enum(['new', 'in_progress', 'completed']).default('new'),
+  created_at: DateTime(),
+  updated_at: DateTime(),
+})
+
+export const ContactCreate = z.object({
+  name: Str({ example: '山田太郎', description: 'お名前' }),
+  email: Email({ example: 'taro@example.com', description: 'メールアドレス' }),
+  phone: Str({
+    required: false,
+    example: '03-1234-5678',
+    description: '電話番号',
+  }),
+  company: Str({
+    required: false,
+    example: '株式会社Example',
+    description: '会社名',
+  }),
+  subject: Str({
+    example: 'サービスについてのお問い合わせ',
+    description: '件名',
+  }),
+  message: Str({
+    example: 'サービスの詳細について教えてください。',
+    description: 'お問い合わせ内容',
+  }),
 })


### PR DESCRIPTION
## Summary
- お問い合わせフォームのデータを保存・管理するためのAPIを実装
- D1データベースにcontactsテーブルを追加
- RESTfulなエンドポイント設計でCRUD操作を提供

## Changes
### 新機能
- `POST /contacts` - お問い合わせ作成エンドポイント
- `GET /contacts` - お問い合わせ一覧エンドポイント（ページネーション、ステータスフィルタ付き）
- `GET /contacts/:contactId` - お問い合わせ詳細エンドポイント

### データベース
- `migrations/0002_create_contacts_table.sql` - contactsテーブルのマイグレーション
- インデックス追加（status, email, created_at）でクエリパフォーマンスを最適化

### セキュリティ
- 既存のAPIキー認証ミドルウェアを適用
- Zodによる入力値バリデーション
- nanoidによるセキュアなID生成

## Test plan
- [ ] `bun run dev` でローカル開発サーバーが起動することを確認
- [ ] `bun run db:migrate:local` でcontactsテーブルが作成されることを確認
- [ ] `bun run test` ですべてのテストが成功することを確認
- [ ] POST /contacts でお問い合わせが作成できることを確認
- [ ] GET /contacts でお問い合わせ一覧が取得できることを確認
- [ ] GET /contacts/:id で個別のお問い合わせが取得できることを確認
- [ ] production環境でAPIキー認証が機能することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)